### PR TITLE
`export const prerender = true`の定義を `+layout.svelte`から`+layout.server.ts`へ移す

### DIFF
--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,4 @@
 <script lang='ts'>
-	export const prerender = true;
-
 	import 'uno.css';
 	import '@unocss/reset/normalize.css';
 


### PR DESCRIPTION
fixes: #34 
ちゃんとprerenderingするには `+layout.js` or `+layout.server.js`に定義する必要がある

https://kit.svelte.jp/docs/page-options

このprojectはstaticなのでserver prefixがついたfileはビルド時に全て評価される。
そのため、`prerender`の定義は`+layout.server.ts`に今回は定義する