### PR TITLE
feat(pre-commit): Run secretlint only if staged files exist

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,4 +3,7 @@
 # get the list of staged files
 files=$(git diff --cached --name-only --diff-filter=ACM --relative="")
 
-pnpm dlx @secretlint/quick-start $files
+# if files are not empty, run secretlint
+if [ -n "$files" ]; then
+  pnpm dlx @secretlint/quick-start $files
+fi


### PR DESCRIPTION
This commit modifies the pre-commit hook to run secretlint only when there are staged files. Previously, secretlint was run regardless of whether there were staged files or not, which could lead to unnecessary linting runs.