### PR TITLE
fix(eslint): `svelte/valid-compile`をoff

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,6 +33,7 @@ export default antfu(
 	{
 		files: ['**/*.svelte', '**/*.svelte'],
 		rules: {
+			'svelte/valid-compile': 'off',
 			'svelte/button-has-type': 'error',
 			'svelte/require-each-key': 'error',
 			'svelte/valid-each-key': 'error',

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -2,9 +2,6 @@
 	import { page } from '$app/stores';
 </script>
 
-<!-- eslint-disable svelte/valid-compile -->
-<!-- svelte-ignore element_invalid_self_closing_tag -->
-
 {#if $page.error != null}
 	<div class='grid place-content-center place-items-center'>
 		<enhanced:img alt='some alt text' src='$/assets/404.png' />


### PR DESCRIPTION
defaultでonになっているが、eslint-plugin-svelteのcommitterといらないよねという話になったので除外

理由としては
- svelte compilerの結果をeslintにかけているのでたまにカバーできなくてエラーになる
- そもそもsvelteはcompileプロセスあるのでeslintでチェックしなくてよくない？
- Svelte5リリースに伴ってルール自体を廃止するかも