### PR TITLE
feat(uno.css.config): prefixを指定

### DIFF
--- a/uno.config.ts
+++ b/uno.config.ts
@@ -9,7 +9,7 @@ import {
 export default defineConfig({
 	presets: [
 		presetUno(), // defaultの設定。
-		presetAttributify(), // class属性ではなく、属性地に直接書く設定。https://unocss.dev/presets/attributify
+		presetAttributify({ prefix: 'uno-', prefixedOnly: true }), // class属性ではなく、属性地に直接書く設定。https://unocss.dev/presets/attributify
 		presetMini(), // Tailwind互換の最小限の設定を含む。 Aspect ration とか。 https://unocss.dev/presets/mini
 		presetIcons({ autoInstall: true }), // Iconを使うための設定。autoInstallも設定している。https://unocss.dev/presets/icons
 	],


### PR DESCRIPTION

https://unocss.dev/presets/attributify#properties-conflicts

prefixを指定し、`uno-foo`という形でclassを指定するように強制する

属性がconflictすることを防ぐ