### PR TITLE
background colorを追加

### DIFF
--- a/plugins/favicons.js
+++ b/plugins/favicons.js
@@ -14,7 +14,7 @@ const dest = join(staticDir, 'favicons');
 const htmlDest = join(assetDir, 'favicons.html');
 
 /** @satisfies {import('favicons').FaviconOptions} */
-const configuration = { path: `/favicons`, theme_color: '#001330' };
+const configuration = { path: `/favicons`, theme_color: '#001330', background: '#001330' };
 
 async function main() {
 	/** cache key */


### PR DESCRIPTION
appをhome画面に追加したときに背景が白くなるので、`background_color`を追加
https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/How_to/Customize_your_app_colors