### PR TITLE
feat(Logo/_Base.svelte): typeを正確に

### DIFF
--- a/src/lib/Logo/_Base.svelte
+++ b/src/lib/Logo/_Base.svelte
@@ -1,7 +1,8 @@
 <script lang='ts'>
+	import type { HTMLImgAttributes } from 'svelte/elements';
 	import { ensureURL } from '../utils/url';
 
-	const { link, icon, alt, imageClass, ...rest }: { link?: string; icon: string; alt: string; imageClass?: string } = $props();
+	const { link, icon, alt, imageClass, ...rest }: { link?: string; icon: string; imageClass?: string } & Omit<HTMLImgAttributes, 'src' | 'class'> = $props();
 
 	const defaultImageClass = `h-full object-scale-down w-auto`;
 	const _imageClassName = imageClass ?? defaultImageClass;


### PR DESCRIPTION
`Logo/_Base.svelte`のtypeを正確にする