### PR TITLE
feat(Logo/AuDee): svgのsizeをimg tagに追加

### DIFF
--- a/src/lib/Logo/AuDee.svelte
+++ b/src/lib/Logo/AuDee.svelte
@@ -7,6 +7,8 @@
 
 	const alt = `AuDee`;
 	const link = `https://audee.jp/program/show/300008578`;
+	const width = 123.836;
+	const height = 66.126;
 </script>
 
-<Base {alt} {icon} {link} {...rest} />
+<Base {alt} {height} {icon} {link} {width} {...rest} />


### PR DESCRIPTION
fixes: #152 
PageSpeedに指摘されるので、svgのwidth/heightをそのままtagに記載