### PR TITLE
アクセスがあるたびに`_redirects` fileを毎回読みに行くように修正。

### DIFF
--- a/src/handles/redirects.ts
+++ b/src/handles/redirects.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { existsSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import { type Handle, redirect } from '@sveltejs/kit';
 import { createRedirect } from 'cloudflare-redirect-parser';
@@ -8,19 +9,21 @@ import { createRedirect } from 'cloudflare-redirect-parser';
  * base は 下のライブラリ
  * @see https://github.com/bluwy/cloudflare-redirect-parser
  */
-export async function redirects(): Promise<Handle> {
+export const redirects = (async ({ event, resolve }) => {
 	const redirectFile = path.join(import.meta.dirname, '../static/_redirects');
+
+	if (!existsSync(redirectFile)) {
+		return resolve(event);
+	}
 	const redirectContent = await fs.readFile(redirectFile, 'utf-8');
 	const redirectF = createRedirect(redirectContent);
 
-	return async ({ event, resolve }) => {
-		const result = redirectF(event.url.pathname);
+	const result = redirectF(event.url.pathname);
 
-		if (result != null) {
-			const { status, to } = result;
-			return redirect(status, to);
-		}
+	if (result != null) {
+		const { status, to } = result;
+		return redirect(status, to);
+	}
 
-		return resolve(event);
-	};
-}
+	return resolve(event);
+}) satisfies Handle;

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -7,6 +7,6 @@ import { dev } from '$app/environment';
 export const handle = sequence(
 	...[
 		meta, // head に favicon を追加する
-		dev ? await redirects() : [], // `_redirects` を元にリダイレクトを行う (dev 時のみ)
+		dev ? redirects : [], // `_redirects` を元にリダイレクトを行う (dev 時のみ)
 	].flat(),
 );


### PR DESCRIPTION
初回起動時に`_redirects` fileがないとdev serverの起動がエラーになる問題を修正

手元で `./static/_redirects`を消したのちにdevコマンドで立ち上げて動作することを確認済み

fixes: #163 