### PR TITLE
fix(+error.svelte): uno-text-white から uno-textにしてcss size削減

### DIFF
--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -24,7 +24,7 @@
 			alt='error logo'
 			src='$/assets/alisue/beer.png'
 		/>
-		<span uno-text='white'>
+		<span uno-text>
 			{$page.error.message}
 		</span>
 	</h1>


### PR DESCRIPTION
削減？のはず