### PR TITLE
dev 環境で`hooks.server.ts`が読みにいく `_redirects`のfile pathを修正

### DIFF
--- a/src/handles/redirects.ts
+++ b/src/handles/redirects.ts
@@ -10,7 +10,7 @@ import { createRedirect } from 'cloudflare-redirect-parser';
  * @see https://github.com/bluwy/cloudflare-redirect-parser
  */
 export const redirects = (async ({ event, resolve }) => {
-	const redirectFile = path.join(import.meta.dirname, '../static/_redirects');
+	const redirectFile = path.join(import.meta.dirname, '../../static/_redirects');
 
 	if (!existsSync(redirectFile)) {
 		return resolve(event);


### PR DESCRIPTION
fixes: #184 
`_redirects`のpathが間違っていたようで修正