### PR TITLE
refactor(unocss): presetMiniを削除（presetUno に含まれているらしい)

### DIFF
--- a/uno.config.ts
+++ b/uno.config.ts
@@ -3,7 +3,6 @@ import {
 	defineConfig,
 	presetAttributify,
 	presetIcons,
-	presetMini,
 	presetUno,
 	transformerDirectives,
 	transformerVariantGroup,
@@ -13,7 +12,6 @@ export default defineConfig({
 	presets: [
 		presetUno(), // defaultの設定。
 		presetAttributify({ prefix: 'uno-', prefixedOnly: true }), // class属性ではなく、属性地に直接書く設定。https://unocss.dev/presets/attributify
-		presetMini(), // Tailwind互換の最小限の設定を含む。 Aspect ration とか。 https://unocss.dev/presets/mini
 		presetIcons({ autoInstall: isDevelopment }), // Iconを使うための設定。autoInstallも設定している。https://unocss.dev/presets/icons
 	],
 	transformers: [


### PR DESCRIPTION
Documentをよく読んだら, unoMiniは Uno Presetに含まれているようで、指定しなくてもいいらしい
https://unocss.dev/presets/uno

消してみてCSSの中身が変わらないことを確認