### PR TITLE
feat(EasterEgg.svelte): +layout.svelteに記述してあったEasterEggを別componentに切り出し

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,25 +3,16 @@
 	import '@unocss/reset/tailwind-compat.css';
 
 	import Meta from './Meta.svelte';
+	import EasterEgg from './EasterEgg.svelte';
 	import { Backgroud } from '$lib/Backgroud';
 
-	/** EASTER_EGG🐰🥚: ありすえさんのAA */
-	import ALISUE_AA from '$/assets/aa/alisue.txt?raw';
-	/** EASTER_EGG🐰🥚: VIM-JP RADIOのAA */
-	import VIM_JP_RADIO from '$/assets/aa/vim-jp-radio.txt?raw';
-
 	const { children } = $props();
-
-	const log = (s: string) => console.log(s.replaceAll('%', '%%')); // eslint-disable-line no-console
-
-	/** EASTER_EGG🐰🥚: ページが読み込まれた時に、ありすえさんのAAとVIM-JP RADIOのAAをconsole.logで表示 */
-	$effect(() => {
-		log(VIM_JP_RADIO);
-		log(ALISUE_AA);
-	});
 </script>
 
 <Meta />
+
+<!-- EASTER_EGG🐰🥚 -->
+<EasterEgg />
 
 <Backgroud />
 <div

--- a/src/routes/EasterEgg.svelte
+++ b/src/routes/EasterEgg.svelte
@@ -1,0 +1,14 @@
+<script lang='ts'>
+	/** EASTER_EGG🐰🥚: ありすえさんのAA */
+	import ALISUE_AA from '$/assets/aa/alisue.txt?raw';
+	/** EASTER_EGG🐰🥚: VIM-JP RADIOのAA */
+	import VIM_JP_RADIO from '$/assets/aa/vim-jp-radio.txt?raw';
+
+	const log = (s: string) => console.log(s.replaceAll('%', '%%')); // eslint-disable-line no-console
+
+	/** EASTER_EGG🐰🥚: ページが読み込まれた時に、ありすえさんのAAとVIM-JP RADIOのAAをconsole.logで表示 */
+	$effect(() => {
+		log(VIM_JP_RADIO);
+		log(ALISUE_AA);
+	});
+</script>


### PR DESCRIPTION
Related to #103  https://github.com/vim-jp-radio/LP/issues/98

別componentにイースターエッグを退避させてわかりやすくする