### PR TITLE
feat(Background): $effectの戻り値に `cacelAnimation` を追加、ページ遷移時にanimationを終了する

### DIFF
--- a/src/lib/Backgroud/Backgroud.svelte
+++ b/src/lib/Backgroud/Backgroud.svelte
@@ -1,5 +1,5 @@
 <script lang='ts'>
-	import { animate, createCircles } from './circle.js';
+	import { animate, cancelAnimate, createCircles } from './circle.js';
 	import { PrefersReducedMotion } from '$lib/utils/runes.svelte.js';
 
 	/**
@@ -37,19 +37,16 @@
 	});
 
 	$effect(() => {
-		let cancelAnimation: (() => void) | undefined;
 		if (
 			circles?.length > 0
 			&& canvas != null
 			&& ctx != null
 		) {
-			cancelAnimation = animate(canvas, ctx, circles);
+			animate(canvas, ctx, circles);
 		}
 
 		return () => {
-			if (cancelAnimation != null) {
-				cancelAnimation();
-			}
+			cancelAnimate();
 		};
 	});
 </script>

--- a/src/lib/Backgroud/Backgroud.svelte
+++ b/src/lib/Backgroud/Backgroud.svelte
@@ -45,6 +45,7 @@
 			animate(canvas, ctx, circles);
 		}
 
+		/** ページ遷移時にアニメーションをキャンセル */
 		return () => {
 			cancelAnimate();
 		};

--- a/src/lib/Backgroud/Backgroud.svelte
+++ b/src/lib/Backgroud/Backgroud.svelte
@@ -37,13 +37,20 @@
 	});
 
 	$effect(() => {
+		let cancelAnimation: (() => void) | undefined;
 		if (
 			circles?.length > 0
 			&& canvas != null
 			&& ctx != null
 		) {
-			animate(canvas, ctx, circles);
+			cancelAnimation = animate(canvas, ctx, circles);
 		}
+
+		return () => {
+			if (cancelAnimation != null) {
+				cancelAnimation();
+			}
+		};
 	});
 </script>
 

--- a/src/lib/Backgroud/circle.ts
+++ b/src/lib/Backgroud/circle.ts
@@ -147,16 +147,27 @@ function createCircles(
 	return circles;
 }
 
+/** 現在のアニメーションフレーム */
+let frame: number | undefined;
+
 function animate(
 	canvas: HTMLCanvasElement,
 	ctx: CanvasRenderingContext2D,
 	circles: Circle[],
-): void {
-	requestAnimationFrame(() => animate(canvas, ctx, circles));
+): () => void {
+	frame = requestAnimationFrame(() => animate(canvas, ctx, circles));
 	ctx.clearRect(0, 0, canvas.width, canvas.height);
 	circles.forEach(circle => circle.update(circles));
 	ctx.save();
 	ctx.restore();
+
+	return () => {
+		if (frame == null) {
+			return;
+		}
+		cancelAnimationFrame(frame);
+		frame = undefined;
+	};
 }
 
 export { createCircles, animate };

--- a/src/lib/Backgroud/circle.ts
+++ b/src/lib/Backgroud/circle.ts
@@ -154,20 +154,20 @@ function animate(
 	canvas: HTMLCanvasElement,
 	ctx: CanvasRenderingContext2D,
 	circles: Circle[],
-): () => void {
+): void {
 	frame = requestAnimationFrame(() => animate(canvas, ctx, circles));
 	ctx.clearRect(0, 0, canvas.width, canvas.height);
 	circles.forEach(circle => circle.update(circles));
 	ctx.save();
 	ctx.restore();
-
-	return () => {
-		if (frame == null) {
-			return;
-		}
-		cancelAnimationFrame(frame);
-		frame = undefined;
-	};
 }
 
-export { createCircles, animate };
+function cancelAnimate(): void {
+	if (frame == null) {
+		return;
+	}
+	cancelAnimationFrame(frame);
+	frame = undefined;
+}
+
+export { createCircles, animate, cancelAnimate };


### PR DESCRIPTION
シングルページなので実はあってもなくてもいいのだが、念の為本来はこうあるべきなので追加