### PR TITLE
feat(unocss): sveltekit-tweet のclassもunocssによって処理されていたので除外するよう設定

### DIFF
--- a/uno.config.ts
+++ b/uno.config.ts
@@ -18,6 +18,13 @@ export default defineConfig({
 		transformerDirectives(), // @apply等のディレクティブを使うための設定。https://unocss.dev/presets/directives
 		transformerVariantGroup(), // hoverなど `:` で始まるクラスをまとめる設定。https://unocss.dev/presets/variant-group
 	],
+	content: {
+		pipeline: {
+			exclude: [
+				/sveltekit-tweet/,
+			],
+		},
+	},
 	theme: {
 		colors: {
 			'LP-blue': '#1ecfff',


### PR DESCRIPTION
(1.7kbほど余計なcssができていた)

除外しても問題なく表示されることを確認

<img width="824" alt="Screenshot 2024-07-18 at 16 43 20" src="https://github.com/user-attachments/assets/5a684ca2-4702-4eb8-a20b-003251a088ae">
