### PR TITLE
use `on` from svelte5 instead of addEventListener

### DIFF
--- a/src/lib/utils/runes.svelte.ts
+++ b/src/lib/utils/runes.svelte.ts
@@ -1,3 +1,4 @@
+import { on } from 'svelte/events';
 import { browser } from '$app/environment';
 
 /**
@@ -27,7 +28,8 @@ export class PrefersReducedMotion {
 
 		this.#mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
 		this.#isReduced = this.#mediaQuery.matches;
-		this.#mediaQuery.addEventListener('change', (event) => {
+		on(this.#mediaQuery, 'change', (_event) => {
+			const event = _event as MediaQueryListEvent;
 			this.#isReduced = event.matches;
 		});
 	}


### PR DESCRIPTION
addEventListenerの代わりに `on` を使う方がいいらしい（svelte5より）なので修正
動作に問題がないことを確認

https://svelte-5-preview.vercel.app/docs/imports#svelte-events

検証がめんどくさいので no look でokでも良さそう