### PR TITLE
patch sveltekit-tweet

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,10 @@
 		"typescript-svelte-plugin": "^0.3.39",
 		"unocss": "^0.60.4",
 		"vite": "^5.3.3"
+	},
+	"pnpm": {
+		"patchedDependencies": {
+			"sveltekit-tweet@0.0.18": "patches/sveltekit-tweet@0.0.18.patch"
+		}
 	}
 }

--- a/patches/sveltekit-tweet@0.0.18.patch
+++ b/patches/sveltekit-tweet@0.0.18.patch
@@ -1,0 +1,32 @@
+diff --git a/dist/components/AvatarImg.svelte b/dist/components/AvatarImg.svelte
+index 62697deab3e67c64114cf7cd69c1c4bf219290db..c1300efab6175709cf94fe684bbd0a3eea8b4820 100644
+--- a/dist/components/AvatarImg.svelte
++++ b/dist/components/AvatarImg.svelte
+@@ -5,4 +5,4 @@ export let height;
+ export let style = "";
+ </script>
+ 
+-<img {src} {alt} {width} {height} {style} />
++<img {src} {alt} {width} {height} {style} loading="lazy" />
+diff --git a/dist/components/EmbeddedTweet.svelte b/dist/components/EmbeddedTweet.svelte
+index 68c2f2e770effdaae4a24f44ba11891a2980891f..76ff2fcd1478c9c4c57e1208a8cf168a72df5528 100644
+--- a/dist/components/EmbeddedTweet.svelte
++++ b/dist/components/EmbeddedTweet.svelte
+@@ -9,7 +9,6 @@ import TweetActions from "./TweetActions.svelte";
+ import TweetReplies from "./TweetReplies.svelte";
+ export let tweet;
+ export let components = {};
+-console.info(`using tweet ${JSON.stringify(tweet)}`);
+ let enrichedTweet;
+ try {
+   enrichedTweet = enrichTweet(tweet);
+diff --git a/dist/components/MediaImg.svelte b/dist/components/MediaImg.svelte
+index c4cb5218112742d52aabd391d6443e19eba3ca7e..32e1ad964c3dab0ae743987b6b4284e4a8166f5a 100644
+--- a/dist/components/MediaImg.svelte
++++ b/dist/components/MediaImg.svelte
+@@ -4,4 +4,4 @@ export let className = "";
+ export let draggable = false;
+ </script>
+ 
+-<img src={src} alt={alt} class={className} draggable={draggable} />
++<img src={src} alt={alt} class={className} draggable={draggable} loading="lazy" />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  sveltekit-tweet@0.0.18:
+    hash: kakmzkcvrejldgrmunenwizfwm
+    path: patches/sveltekit-tweet@0.0.18.patch
+
 importers:
 
   .:
@@ -80,7 +85,7 @@ importers:
         version: 1.0.3(@sveltejs/kit@2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.175)(vite@5.3.3(@types/node@20.14.10)(terser@5.31.1)))(svelte@5.0.0-next.175)(vite@5.3.3(@types/node@20.14.10)(terser@5.31.1)))
       sveltekit-tweet:
         specifier: ^0.0.18
-        version: 0.0.18(svelte@5.0.0-next.175)
+        version: 0.0.18(patch_hash=kakmzkcvrejldgrmunenwizfwm)(svelte@5.0.0-next.175)
       tslib:
         specifier: ^2.6.3
         version: 2.6.3
@@ -11321,7 +11326,7 @@ snapshots:
       '@sveltejs/kit': 2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.175)(vite@5.3.3(@types/node@20.14.10)(terser@5.31.1)))(svelte@5.0.0-next.175)(vite@5.3.3(@types/node@20.14.10)(terser@5.31.1))
       html-minifier-terser: 7.2.0
 
-  sveltekit-tweet@0.0.18(svelte@5.0.0-next.175):
+  sveltekit-tweet@0.0.18(patch_hash=kakmzkcvrejldgrmunenwizfwm)(svelte@5.0.0-next.175):
     dependencies:
       date-fns: 2.30.0
       scn: 1.0.19


### PR DESCRIPTION
fixes: #205 
related to: https://github.com/vim-jp-radio/LP/pull/212


sveltekit-tweetの最適化が不十分な実装にpatch
- 不要なconsole.infoを除く
- img tag に `loading="lazy"` を追加

https://github.com/fayez-nazzal/sveltekit-tweet/pull/5 

https://github.com/fayez-nazzal/sveltekit-tweet/pull/4

avator のlazy load とconsoleに不要な情報が載る問題が解決している


https://github.com/user-attachments/assets/ae09df2f-9be9-41bc-9f6d-d235aa63415a

