### PR TITLE
fix(svelte.config.js): main branch の場合はassetのpathをvim-jp-radio.comからにする

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -50,6 +50,10 @@ const config = {
 		},
 
 		paths: {
+			/**
+      @see https://developers.cloudflare.com/pages/configuration/build-configuration#environment-variables
+      @see https://kit.svelte.jp/docs/configuration#paths
+			 */
 			assets: isDevelopment
 				? '' // もし開発環境ならば、相対パスでアクセスする
 				: process.env.CF_PAGES_BRANCH === 'main'

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -50,7 +50,11 @@ const config = {
 		},
 
 		paths: {
-			assets: isDevelopment ? '' : process.env.CF_PAGES_URL,
+			assets: isDevelopment
+				? '' // もし開発環境ならば、相対パスでアクセスする
+				: process.env.CF_PAGES_BRANCH === 'main'
+					? `https:///vim-jp-radio.com` // もし本番環境で、main ブランチならば、vim-jp-radio.com からアクセスする
+					: process.env.CF_PAGES_URL, // それ以外の場合は、CF_PAGES_URL からアクセスする
 		},
 	},
 };


### PR DESCRIPTION
https://developers.cloudflare.com/pages/configuration/build-configuration/

mainブランチからデプロイされたものに関しては、Asset のurlを vim-jp-radio.com からのpathにする

fixes: #217