### PR TITLE
fix(icon): prefixを変えることでautoinstallのエラーを修正

### DIFF
--- a/src/lib/Heading/Heading.svelte
+++ b/src/lib/Heading/Heading.svelte
@@ -17,7 +17,7 @@
 		{title}<span
 			class='group-hover:visible'
 			uno-color-LP-dark-gray
-			uno-i-ph='hash-bold'
+			uno-i='ph:hash-bold'
 			uno-invisible
 			uno-ml-1
 			uno-text-2xl


### PR DESCRIPTION
https://unocss.dev/presets/icons#icons-preset

`-` 区切りじゃなくて `:` 区切りにしたらautoinstall エラーが消えたので対応


headingをhoverしたときにicon(#)がちゃんと見えていればok