### PR TITLE
feat: corepackを使う

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -17,7 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - name: setup pnpm
+        run: corepack enable
       - uses: actions/setup-node@v4
         with:
           node-version-file: package.json

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"type": "module",
 	"version": "0.0.1",
 	"private": true,
-	"packageManager": "pnpm@9.7.0",
+	"packageManager": "pnpm@9.7.0+sha512.dc09430156b427f5ecfc79888899e1c39d2d690f004be70e05230b72cb173d96839587545d09429b55ac3c429c801b4dc3c0e002f653830a420fa2dd4e3cf9cf",
 	"engines": {
 		"node": ">=20.0.0 <21.0.0"
 	},


### PR DESCRIPTION
corepack を使ってpnpmを管理する方法に変更
手元でもgithub actionsでも`corepack enable` で同じバージョンにできて便利