### PR TITLE
pnpmでnodeのバージョンを指定する

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -18,9 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run secretlint

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -20,7 +20,6 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: package.json
           cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 engine-strict=true
+use-node-version=20.17.0
 @jsr:registry=https://npm.jsr.io

--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
 	"version": "0.0.1",
 	"private": true,
 	"packageManager": "pnpm@9.9.0",
-	"engines": {
-		"node": ">=20.0.0 <21.0.0"
-	},
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",


### PR DESCRIPTION
https://pnpm.io/ja/npmrc#manage-package-manager-versions

これで、localで`pnpm install`をすると自動で該当のnodeが降ってくる

`pnpm install`のcacheがなくなってますが、setup-nodeのcache復元の時間がなくなったので、totalの時間としてはトントンです

キャッシュなし: https://github.com/vim-jp-radio/LP/actions/runs/10930739117/job/30344299772?pr=305
キャッシュあり: https://github.com/vim-jp-radio/LP/actions/runs/10930718440/job/30344231604?pr=305