### PR TITLE
Enhanced ImageをラップしたImage.svelteを作る

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"@ryoppippi/vite-plugin-cloudflare-redirect": "npm:@jsr/ryoppippi__vite-plugin-cloudflare-redirect@^1.0.2",
 		"@std/collections": "npm:@jsr/std__collections@^1.0.5",
 		"@sveltejs/adapter-static": "^3.0.4",
-		"@sveltejs/enhanced-img": "^0.3.4",
+		"@sveltejs/enhanced-img": "^0.3.8",
 		"@sveltejs/kit": "^2.5.26",
 		"@sveltejs/vite-plugin-svelte": "4.0.0-next.7",
 		"@types/node": "^20.16.5",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
 		"svelte-check": "^4.0.0",
 		"svelte-eslint-parser": "^0.41.0",
 		"svelte-preprocess-budoux": "^1.0.2",
-		"sveltekit-html-minifier": "^1.0.3",
 		"sveltweet": "^0.2.6",
 		"tslib": "^2.7.0",
 		"typescript": "^5.5.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"p-retry": "^6.2.0",
 		"renovate": "^38.68.0",
 		"std-env": "^3.7.0",
-		"svelte": "5.0.0-next.223",
+		"svelte": "5.0.0-next.257",
 		"svelte-check": "^4.0.0",
 		"svelte-eslint-parser": "^0.41.0",
 		"svelte-preprocess-budoux": "^1.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
         specifier: ^3.0.4
         version: 3.0.5(@sveltejs/kit@2.5.28(@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))
       '@sveltejs/enhanced-img':
-        specifier: ^0.3.4
-        version: 0.3.4(rollup@4.22.4)(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))
+        specifier: ^0.3.8
+        version: 0.3.8(rollup@4.22.4)(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))
       '@sveltejs/kit':
         specifier: ^2.5.26
         version: 2.5.28(@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))
@@ -1224,15 +1224,6 @@ packages:
     resolution: {integrity: sha512-YGvsvvyxOgv5Uq+sFEdD1yviyrPGs9hocjhIo7uWTj/EAIlbGyk5YA5JrHql3EkJf0tVsyfmEkM3kLK+45hmIw==}
     engines: {node: ^18.12.0 || >= 20.0.0, pnpm: ^8.6.11}
 
-  '@rollup/pluginutils@5.1.0':
-    resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-
   '@rollup/pluginutils@5.1.1':
     resolution: {integrity: sha512-bVRmQqBIyGD+VMihdEV2IBurfIrdW9tD9yzJUL3CBRDbyPBVzQnBSMSgyUZHl1E335rpMRj7r4o683fXLYw8iw==}
     engines: {node: '>=14.0.0'}
@@ -1546,8 +1537,8 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
 
-  '@sveltejs/enhanced-img@0.3.4':
-    resolution: {integrity: sha512-eX+ob5uWr0bTLMKeG9nhhM84aR88hqiLiyEfWZPX7ijhk/wlmYSUX9nOiaVHh2ct1U+Ju9Hhb90Copw+ZNOB8w==}
+  '@sveltejs/enhanced-img@0.3.8':
+    resolution: {integrity: sha512-n66u46ZeqHltiTm0BEjWptYmCrCY0EltEEvakmC7d5o5ZejDbOvOWm914mebbRKaP2Bezv65TNCod/wqvw/0KA==}
     peerDependencies:
       svelte: ^4.0.0 || ^5.0.0-next.0
       vite: '>= 5.0.0'
@@ -6842,14 +6833,6 @@ snapshots:
 
   '@renovatebot/ruby-semver@3.0.23': {}
 
-  '@rollup/pluginutils@5.1.0(rollup@4.22.4)':
-    dependencies:
-      '@types/estree': 1.0.5
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
-    optionalDependencies:
-      rollup: 4.22.4
-
   '@rollup/pluginutils@5.1.1(rollup@4.22.4)':
     dependencies:
       '@types/estree': 1.0.6
@@ -7263,7 +7246,7 @@ snapshots:
     dependencies:
       '@sveltejs/kit': 2.5.28(@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))
 
-  '@sveltejs/enhanced-img@0.3.4(rollup@4.22.4)(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))':
+  '@sveltejs/enhanced-img@0.3.8(rollup@4.22.4)(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))':
     dependencies:
       magic-string: 0.30.11
       svelte: 5.0.0-next.223
@@ -11542,7 +11525,7 @@ snapshots:
 
   vite-imagetools@7.0.4(rollup@4.22.4):
     dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.22.4)
+      '@rollup/pluginutils': 5.1.1(rollup@4.22.4)
       imagetools-core: 7.0.1
       sharp: 0.33.5
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,9 +81,6 @@ importers:
       svelte-preprocess-budoux:
         specifier: ^1.0.2
         version: 1.0.2
-      sveltekit-html-minifier:
-        specifier: ^1.0.3
-        version: 1.0.3(@sveltejs/kit@2.5.28(@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))
       sveltweet:
         specifier: ^0.2.6
         version: 0.2.8(@sveltejs/kit@2.5.28(@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.223)
@@ -2116,9 +2113,6 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  camel-case@4.1.2:
-    resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
-
   camelcase-keys@6.2.2:
     resolution: {integrity: sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==}
     engines: {node: '>=8'}
@@ -2178,10 +2172,6 @@ packages:
   cjs-module-lexer@1.4.1:
     resolution: {integrity: sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==}
 
-  clean-css@5.3.3:
-    resolution: {integrity: sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==}
-    engines: {node: '>= 10.0'}
-
   clean-git-ref@2.0.1:
     resolution: {integrity: sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==}
 
@@ -2238,10 +2228,6 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
-
-  commander@10.0.1:
-    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
-    engines: {node: '>=14'}
 
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
@@ -2457,9 +2443,6 @@ packages:
 
   domutils@3.1.0:
     resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
-
-  dot-case@3.0.4:
-    resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
 
   dotenv@16.4.5:
     resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
@@ -3097,11 +3080,6 @@ packages:
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
-
-  html-minifier-terser@7.2.0:
-    resolution: {integrity: sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==}
-    engines: {node: ^14.13.1 || >=16.0.0}
-    hasBin: true
 
   http-cache-semantics@4.1.1:
     resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
@@ -4069,9 +4047,6 @@ packages:
   package-manager-detector@0.2.0:
     resolution: {integrity: sha512-E385OSk9qDcXhcM9LNSe4sdhx8a9mAPrZ4sMLW+tmxl5ZuGtPUcdFu+MPP2jbgiWAZ6Pfe5soGFMd+0Db5Vrog==}
 
-  param-case@3.0.4:
-    resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
-
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -4334,10 +4309,6 @@ packages:
   regjsparser@0.10.0:
     resolution: {integrity: sha512-qx+xQGZVsy55CH0a1hiVwHmqjLryfh7wQyF5HO07XJ9f7dQMY/gPQHhlyDkIzJKC+x2fUCpCcUODUUUFrm7SHA==}
     hasBin: true
-
-  relateurl@0.2.7:
-    resolution: {integrity: sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==}
-    engines: {node: '>= 0.10'}
 
   remark-github@10.1.0:
     resolution: {integrity: sha512-q0BTFb41N6/uXQVkxRwLRTFRfLFPYP+8li26Js5XC0GKritCSaxrftd+t+8sfN+1i9BtmJPUKoS7CZwtccj0Fg==}
@@ -4711,11 +4682,6 @@ packages:
   svelte@5.0.0-next.244:
     resolution: {integrity: sha512-whSOcKdpuAFd5xD9J2EhuHeRs4J4nHis6NSUKRXpC3HQoCmsoKhyIldMjiv6QFkQpe6QMsid8lwvgLXkZTSC/A==}
     engines: {node: '>=18'}
-
-  sveltekit-html-minifier@1.0.3:
-    resolution: {integrity: sha512-wG2eR0gINur07FMUUR3q/eGcs2IIfZ0aPR5Ue7X7H//v2a/fjmaVm46lSkqUG0rYqezr4pQNzjiyAQLx7iU8eg==}
-    peerDependencies:
-      '@sveltejs/kit': '>=1.5.0 <3.0.0'
 
   sveltweet@0.2.8:
     resolution: {integrity: sha512-b4CZWmNKdGQ0xTUnI36SZQ2O3wGzibwRFIaoXDHziTrX+sXtGtwmWi6z8dO0Fo8zu1sI0HOewP2RoGOrXxSIRQ==}
@@ -6485,6 +6451,7 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
+    optional: true
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
@@ -8048,11 +8015,6 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  camel-case@4.1.2:
-    dependencies:
-      pascal-case: 3.1.2
-      tslib: 2.7.0
-
   camelcase-keys@6.2.2:
     dependencies:
       camelcase: 5.3.1
@@ -8112,10 +8074,6 @@ snapshots:
 
   cjs-module-lexer@1.4.1: {}
 
-  clean-css@5.3.3:
-    dependencies:
-      source-map: 0.6.1
-
   clean-git-ref@2.0.1: {}
 
   clean-regexp@1.0.0:
@@ -8170,13 +8128,12 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
-  commander@10.0.1: {}
-
   commander@11.1.0: {}
 
   commander@12.1.0: {}
 
-  commander@2.20.3: {}
+  commander@2.20.3:
+    optional: true
 
   comment-parser@1.4.1: {}
 
@@ -8366,11 +8323,6 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
-
-  dot-case@3.0.4:
-    dependencies:
-      no-case: 3.0.4
-      tslib: 2.7.0
 
   dotenv@16.4.5: {}
 
@@ -9199,16 +9151,6 @@ snapshots:
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
-
-  html-minifier-terser@7.2.0:
-    dependencies:
-      camel-case: 4.1.2
-      clean-css: 5.3.3
-      commander: 10.0.1
-      entities: 4.5.0
-      param-case: 3.0.4
-      relateurl: 0.2.7
-      terser: 5.31.6
 
   http-cache-semantics@4.1.1: {}
 
@@ -10383,11 +10325,6 @@ snapshots:
 
   package-manager-detector@0.2.0: {}
 
-  param-case@3.0.4:
-    dependencies:
-      dot-case: 3.0.4
-      tslib: 2.7.0
-
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -10685,8 +10622,6 @@ snapshots:
   regjsparser@0.10.0:
     dependencies:
       jsesc: 0.5.0
-
-  relateurl@0.2.7: {}
 
   remark-github@10.1.0:
     dependencies:
@@ -11266,11 +11201,6 @@ snapshots:
       magic-string: 0.30.11
       zimmerframe: 1.1.2
 
-  sveltekit-html-minifier@1.0.3(@sveltejs/kit@2.5.28(@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))):
-    dependencies:
-      '@sveltejs/kit': 2.5.28(@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))
-      html-minifier-terser: 7.2.0
-
   sveltweet@0.2.8(@sveltejs/kit@2.5.28(@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.223):
     dependencies:
       '@sveltejs/kit': 2.5.28(@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))
@@ -11321,6 +11251,7 @@ snapshots:
       acorn: 8.12.1
       commander: 2.20.3
       source-map-support: 0.5.21
+    optional: true
 
   text-table@0.2.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ importers:
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^3.0.0
-        version: 3.7.1(@typescript-eslint/utils@8.6.0(eslint@9.11.0(jiti@1.21.6))(typescript@5.6.2))(@unocss/eslint-plugin@0.62.4(eslint@9.11.0(jiti@1.21.6))(typescript@5.6.2))(@vue/compiler-sfc@3.4.27)(eslint-plugin-format@0.1.2(eslint@9.11.0(jiti@1.21.6)))(eslint-plugin-svelte@2.44.0(eslint@9.11.0(jiti@1.21.6))(svelte@5.0.0-next.223))(eslint@9.11.0(jiti@1.21.6))(svelte-eslint-parser@0.41.1(svelte@5.0.0-next.223))(svelte@5.0.0-next.223)(typescript@5.6.2)
+        version: 3.7.1(@typescript-eslint/utils@8.6.0(eslint@9.11.0(jiti@1.21.6))(typescript@5.6.2))(@unocss/eslint-plugin@0.62.4(eslint@9.11.0(jiti@1.21.6))(typescript@5.6.2))(@vue/compiler-sfc@3.4.27)(eslint-plugin-format@0.1.2(eslint@9.11.0(jiti@1.21.6)))(eslint-plugin-svelte@2.44.0(eslint@9.11.0(jiti@1.21.6))(svelte@5.0.0-next.257))(eslint@9.11.0(jiti@1.21.6))(svelte-eslint-parser@0.41.1(svelte@5.0.0-next.257))(svelte@5.0.0-next.257)(typescript@5.6.2)
       '@iconify-json/ph':
         specifier: ^1.2.0
         version: 1.2.0
@@ -26,16 +26,16 @@ importers:
         version: '@jsr/std__collections@1.0.5'
       '@sveltejs/adapter-static':
         specifier: ^3.0.4
-        version: 3.0.5(@sveltejs/kit@2.5.28(@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))
+        version: 3.0.5(@sveltejs/kit@2.5.28(@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.257)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.257)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))
       '@sveltejs/enhanced-img':
         specifier: ^0.3.8
-        version: 0.3.8(rollup@4.22.4)(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))
+        version: 0.3.8(rollup@4.22.4)(svelte@5.0.0-next.257)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))
       '@sveltejs/kit':
         specifier: ^2.5.26
-        version: 2.5.28(@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))
+        version: 2.5.28(@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.257)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.257)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))
       '@sveltejs/vite-plugin-svelte':
         specifier: 4.0.0-next.7
-        version: 4.0.0-next.7(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))
+        version: 4.0.0-next.7(svelte@5.0.0-next.257)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))
       '@types/node':
         specifier: ^20.16.5
         version: 20.16.5
@@ -56,7 +56,7 @@ importers:
         version: 0.1.2(eslint@9.11.0(jiti@1.21.6))
       eslint-plugin-svelte:
         specifier: ^2.43.0
-        version: 2.44.0(eslint@9.11.0(jiti@1.21.6))(svelte@5.0.0-next.223)
+        version: 2.44.0(eslint@9.11.0(jiti@1.21.6))(svelte@5.0.0-next.257)
       favicons:
         specifier: ^7.2.0
         version: 7.2.0
@@ -70,20 +70,20 @@ importers:
         specifier: ^3.7.0
         version: 3.7.0
       svelte:
-        specifier: 5.0.0-next.223
-        version: 5.0.0-next.223
+        specifier: 5.0.0-next.257
+        version: 5.0.0-next.257
       svelte-check:
         specifier: ^4.0.0
-        version: 4.0.2(picomatch@4.0.2)(svelte@5.0.0-next.223)(typescript@5.6.2)
+        version: 4.0.2(picomatch@4.0.2)(svelte@5.0.0-next.257)(typescript@5.6.2)
       svelte-eslint-parser:
         specifier: ^0.41.0
-        version: 0.41.1(svelte@5.0.0-next.223)
+        version: 0.41.1(svelte@5.0.0-next.257)
       svelte-preprocess-budoux:
         specifier: ^1.0.2
         version: 1.0.2
       sveltweet:
         specifier: ^0.2.6
-        version: 0.2.8(@sveltejs/kit@2.5.28(@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.223)
+        version: 0.2.8(@sveltejs/kit@2.5.28(@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.257)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.257)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.257)
       tslib:
         specifier: ^2.7.0
         version: 2.7.0
@@ -92,7 +92,7 @@ importers:
         version: 5.6.2
       typescript-svelte-plugin:
         specifier: ^0.3.41
-        version: 0.3.41(svelte@5.0.0-next.223)(typescript@5.6.2)
+        version: 0.3.41(svelte@5.0.0-next.257)(typescript@5.6.2)
       unocss:
         specifier: ^0.62.3
         version: 0.62.4(postcss@8.4.45)(rollup@4.22.4)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))
@@ -1944,8 +1944,9 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
-  aria-query@5.3.0:
-    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
 
   array-buffer-byte-length@1.0.1:
     resolution: {integrity: sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==}
@@ -4666,12 +4667,8 @@ packages:
       svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
       typescript: ^4.9.4 || ^5.0.0
 
-  svelte@5.0.0-next.223:
-    resolution: {integrity: sha512-bo6Wj33evujynDnn1wAk55QaGJuLS2TEcyF28zSqsBBevs+wq3isMPeAkUdESFqPj3oI4hvF/gDuxu4ZFNRznw==}
-    engines: {node: '>=18'}
-
-  svelte@5.0.0-next.244:
-    resolution: {integrity: sha512-whSOcKdpuAFd5xD9J2EhuHeRs4J4nHis6NSUKRXpC3HQoCmsoKhyIldMjiv6QFkQpe6QMsid8lwvgLXkZTSC/A==}
+  svelte@5.0.0-next.257:
+    resolution: {integrity: sha512-fiTimH9UbJ0aNUcsOyaRgq4MZdmgN6lv3sQ2sOMv9V6haK0emsmYCm8Pw10+ej6FhXGALxuWvNdoi7VKMaeIIA==}
     engines: {node: '>=18'}
 
   sveltweet@0.2.8:
@@ -5203,7 +5200,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@antfu/eslint-config@3.7.1(@typescript-eslint/utils@8.6.0(eslint@9.11.0(jiti@1.21.6))(typescript@5.6.2))(@unocss/eslint-plugin@0.62.4(eslint@9.11.0(jiti@1.21.6))(typescript@5.6.2))(@vue/compiler-sfc@3.4.27)(eslint-plugin-format@0.1.2(eslint@9.11.0(jiti@1.21.6)))(eslint-plugin-svelte@2.44.0(eslint@9.11.0(jiti@1.21.6))(svelte@5.0.0-next.223))(eslint@9.11.0(jiti@1.21.6))(svelte-eslint-parser@0.41.1(svelte@5.0.0-next.223))(svelte@5.0.0-next.223)(typescript@5.6.2)':
+  '@antfu/eslint-config@3.7.1(@typescript-eslint/utils@8.6.0(eslint@9.11.0(jiti@1.21.6))(typescript@5.6.2))(@unocss/eslint-plugin@0.62.4(eslint@9.11.0(jiti@1.21.6))(typescript@5.6.2))(@vue/compiler-sfc@3.4.27)(eslint-plugin-format@0.1.2(eslint@9.11.0(jiti@1.21.6)))(eslint-plugin-svelte@2.44.0(eslint@9.11.0(jiti@1.21.6))(svelte@5.0.0-next.257))(eslint@9.11.0(jiti@1.21.6))(svelte-eslint-parser@0.41.1(svelte@5.0.0-next.257))(svelte@5.0.0-next.257)(typescript@5.6.2)':
     dependencies:
       '@antfu/install-pkg': 0.4.1
       '@clack/prompts': 0.7.0
@@ -5224,7 +5221,7 @@ snapshots:
       eslint-plugin-jsonc: 2.16.0(eslint@9.11.0(jiti@1.21.6))
       eslint-plugin-n: 17.10.3(eslint@9.11.0(jiti@1.21.6))
       eslint-plugin-no-only-tests: 3.3.0
-      eslint-plugin-perfectionist: 3.6.0(eslint@9.11.0(jiti@1.21.6))(svelte-eslint-parser@0.41.1(svelte@5.0.0-next.223))(svelte@5.0.0-next.223)(typescript@5.6.2)(vue-eslint-parser@9.4.3(eslint@9.11.0(jiti@1.21.6)))
+      eslint-plugin-perfectionist: 3.6.0(eslint@9.11.0(jiti@1.21.6))(svelte-eslint-parser@0.41.1(svelte@5.0.0-next.257))(svelte@5.0.0-next.257)(typescript@5.6.2)(vue-eslint-parser@9.4.3(eslint@9.11.0(jiti@1.21.6)))
       eslint-plugin-regexp: 2.6.0(eslint@9.11.0(jiti@1.21.6))
       eslint-plugin-toml: 0.11.1(eslint@9.11.0(jiti@1.21.6))
       eslint-plugin-unicorn: 55.0.0(eslint@9.11.0(jiti@1.21.6))
@@ -5244,8 +5241,8 @@ snapshots:
     optionalDependencies:
       '@unocss/eslint-plugin': 0.62.4(eslint@9.11.0(jiti@1.21.6))(typescript@5.6.2)
       eslint-plugin-format: 0.1.2(eslint@9.11.0(jiti@1.21.6))
-      eslint-plugin-svelte: 2.44.0(eslint@9.11.0(jiti@1.21.6))(svelte@5.0.0-next.223)
-      svelte-eslint-parser: 0.41.1(svelte@5.0.0-next.223)
+      eslint-plugin-svelte: 2.44.0(eslint@9.11.0(jiti@1.21.6))(svelte@5.0.0-next.257)
+      svelte-eslint-parser: 0.41.1(svelte@5.0.0-next.257)
     transitivePeerDependencies:
       - '@typescript-eslint/utils'
       - '@vue/compiler-sfc'
@@ -7242,23 +7239,23 @@ snapshots:
       - supports-color
       - typescript
 
-  '@sveltejs/adapter-static@3.0.5(@sveltejs/kit@2.5.28(@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))':
+  '@sveltejs/adapter-static@3.0.5(@sveltejs/kit@2.5.28(@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.257)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.257)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))':
     dependencies:
-      '@sveltejs/kit': 2.5.28(@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))
+      '@sveltejs/kit': 2.5.28(@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.257)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.257)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))
 
-  '@sveltejs/enhanced-img@0.3.8(rollup@4.22.4)(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))':
+  '@sveltejs/enhanced-img@0.3.8(rollup@4.22.4)(svelte@5.0.0-next.257)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))':
     dependencies:
       magic-string: 0.30.11
-      svelte: 5.0.0-next.223
-      svelte-parse-markup: 0.1.5(svelte@5.0.0-next.223)
+      svelte: 5.0.0-next.257
+      svelte-parse-markup: 0.1.5(svelte@5.0.0-next.257)
       vite: 5.4.7(@types/node@20.16.5)(terser@5.31.6)
       vite-imagetools: 7.0.4(rollup@4.22.4)
     transitivePeerDependencies:
       - rollup
 
-  '@sveltejs/kit@2.5.28(@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))':
+  '@sveltejs/kit@2.5.28(@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.257)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.257)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 4.0.0-next.7(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))
+      '@sveltejs/vite-plugin-svelte': 4.0.0-next.7(svelte@5.0.0-next.257)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.0.0
@@ -7270,27 +7267,27 @@ snapshots:
       sade: 1.8.1
       set-cookie-parser: 2.7.0
       sirv: 2.0.4
-      svelte: 5.0.0-next.223
+      svelte: 5.0.0-next.257
       tiny-glob: 0.2.9
       vite: 5.4.7(@types/node@20.16.5)(terser@5.31.6)
 
-  '@sveltejs/vite-plugin-svelte-inspector@3.0.0-next.3(@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))':
+  '@sveltejs/vite-plugin-svelte-inspector@3.0.0-next.3(@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.257)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.257)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 4.0.0-next.7(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))
+      '@sveltejs/vite-plugin-svelte': 4.0.0-next.7(svelte@5.0.0-next.257)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))
       debug: 4.3.6
-      svelte: 5.0.0-next.223
+      svelte: 5.0.0-next.257
       vite: 5.4.7(@types/node@20.16.5)(terser@5.31.6)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))':
+  '@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.257)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 3.0.0-next.3(@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))
+      '@sveltejs/vite-plugin-svelte-inspector': 3.0.0-next.3(@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.257)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.257)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))
       debug: 4.3.6
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.11
-      svelte: 5.0.0-next.223
+      svelte: 5.0.0-next.257
       vite: 5.4.7(@types/node@20.16.5)(terser@5.31.6)
       vitefu: 1.0.2(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))
     transitivePeerDependencies:
@@ -7814,9 +7811,7 @@ snapshots:
 
   argparse@2.0.1: {}
 
-  aria-query@5.3.0:
-    dependencies:
-      dequal: 2.0.3
+  aria-query@5.3.2: {}
 
   array-buffer-byte-length@1.0.1:
     dependencies:
@@ -8575,7 +8570,7 @@ snapshots:
 
   eslint-plugin-no-only-tests@3.3.0: {}
 
-  eslint-plugin-perfectionist@3.6.0(eslint@9.11.0(jiti@1.21.6))(svelte-eslint-parser@0.41.1(svelte@5.0.0-next.223))(svelte@5.0.0-next.223)(typescript@5.6.2)(vue-eslint-parser@9.4.3(eslint@9.11.0(jiti@1.21.6))):
+  eslint-plugin-perfectionist@3.6.0(eslint@9.11.0(jiti@1.21.6))(svelte-eslint-parser@0.41.1(svelte@5.0.0-next.257))(svelte@5.0.0-next.257)(typescript@5.6.2)(vue-eslint-parser@9.4.3(eslint@9.11.0(jiti@1.21.6))):
     dependencies:
       '@typescript-eslint/types': 8.6.0
       '@typescript-eslint/utils': 8.6.0(eslint@9.11.0(jiti@1.21.6))(typescript@5.6.2)
@@ -8583,8 +8578,8 @@ snapshots:
       minimatch: 9.0.5
       natural-compare-lite: 1.4.0
     optionalDependencies:
-      svelte: 5.0.0-next.223
-      svelte-eslint-parser: 0.41.1(svelte@5.0.0-next.223)
+      svelte: 5.0.0-next.257
+      svelte-eslint-parser: 0.41.1(svelte@5.0.0-next.257)
       vue-eslint-parser: 9.4.3(eslint@9.11.0(jiti@1.21.6))
     transitivePeerDependencies:
       - supports-color
@@ -8601,7 +8596,7 @@ snapshots:
       regexp-ast-analysis: 0.7.1
       scslre: 0.3.0
 
-  eslint-plugin-svelte@2.44.0(eslint@9.11.0(jiti@1.21.6))(svelte@5.0.0-next.223):
+  eslint-plugin-svelte@2.44.0(eslint@9.11.0(jiti@1.21.6))(svelte@5.0.0-next.257):
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@9.11.0(jiti@1.21.6))
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -8614,9 +8609,9 @@ snapshots:
       postcss-safe-parser: 6.0.0(postcss@8.4.45)
       postcss-selector-parser: 6.1.2
       semver: 7.6.3
-      svelte-eslint-parser: 0.41.1(svelte@5.0.0-next.223)
+      svelte-eslint-parser: 0.41.1(svelte@5.0.0-next.257)
     optionalDependencies:
-      svelte: 5.0.0-next.223
+      svelte: 5.0.0-next.257
     transitivePeerDependencies:
       - ts-node
 
@@ -8764,7 +8759,7 @@ snapshots:
   esrap@1.2.2:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
 
   esrecurse@4.3.0:
     dependencies:
@@ -9334,7 +9329,7 @@ snapshots:
 
   is-reference@3.0.2:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
 
   is-regex@1.1.4:
     dependencies:
@@ -11100,19 +11095,19 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@4.0.2(picomatch@4.0.2)(svelte@5.0.0-next.223)(typescript@5.6.2):
+  svelte-check@4.0.2(picomatch@4.0.2)(svelte@5.0.0-next.257)(typescript@5.6.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 3.6.0
       fdir: 6.3.0(picomatch@4.0.2)
       picocolors: 1.1.0
       sade: 1.8.1
-      svelte: 5.0.0-next.223
+      svelte: 5.0.0-next.257
       typescript: 5.6.2
     transitivePeerDependencies:
       - picomatch
 
-  svelte-eslint-parser@0.41.1(svelte@5.0.0-next.223):
+  svelte-eslint-parser@0.41.1(svelte@5.0.0-next.257):
     dependencies:
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
@@ -11120,15 +11115,11 @@ snapshots:
       postcss: 8.4.45
       postcss-scss: 4.0.9(postcss@8.4.45)
     optionalDependencies:
-      svelte: 5.0.0-next.223
+      svelte: 5.0.0-next.257
 
-  svelte-parse-markup@0.1.5(svelte@5.0.0-next.223):
+  svelte-parse-markup@0.1.5(svelte@5.0.0-next.257):
     dependencies:
-      svelte: 5.0.0-next.223
-
-  svelte-parse-markup@0.1.5(svelte@5.0.0-next.244):
-    dependencies:
-      svelte: 5.0.0-next.244
+      svelte: 5.0.0-next.257
 
   svelte-preprocess-budoux@1.0.2:
     dependencies:
@@ -11136,8 +11127,8 @@ snapshots:
       defu: 6.1.4
       magic-string: 0.30.11
       node-html-parser: 6.1.13
-      svelte: 5.0.0-next.244
-      svelte-parse-markup: 0.1.5(svelte@5.0.0-next.244)
+      svelte: 5.0.0-next.257
+      svelte-parse-markup: 0.1.5(svelte@5.0.0-next.257)
       zimmerframe: 1.1.2
     transitivePeerDependencies:
       - bufferutil
@@ -11145,21 +11136,21 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  svelte2tsx@0.7.18(svelte@5.0.0-next.223)(typescript@5.6.2):
+  svelte2tsx@0.7.18(svelte@5.0.0-next.257)(typescript@5.6.2):
     dependencies:
       dedent-js: 1.0.1
       pascal-case: 3.1.2
-      svelte: 5.0.0-next.223
+      svelte: 5.0.0-next.257
       typescript: 5.6.2
 
-  svelte@5.0.0-next.223:
+  svelte@5.0.0-next.257:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       acorn: 8.12.1
       acorn-typescript: 1.4.13(acorn@8.12.1)
-      aria-query: 5.3.0
+      aria-query: 5.3.2
       axobject-query: 4.1.0
       esm-env: 1.0.0
       esrap: 1.2.2
@@ -11168,26 +11159,10 @@ snapshots:
       magic-string: 0.30.11
       zimmerframe: 1.1.2
 
-  svelte@5.0.0-next.244:
+  sveltweet@0.2.8(@sveltejs/kit@2.5.28(@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.257)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.257)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.257):
     dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@jridgewell/sourcemap-codec': 1.5.0
-      '@types/estree': 1.0.5
-      acorn: 8.12.1
-      acorn-typescript: 1.4.13(acorn@8.12.1)
-      aria-query: 5.3.0
-      axobject-query: 4.1.0
-      esm-env: 1.0.0
-      esrap: 1.2.2
-      is-reference: 3.0.2
-      locate-character: 3.0.0
-      magic-string: 0.30.11
-      zimmerframe: 1.1.2
-
-  sveltweet@0.2.8(@sveltejs/kit@2.5.28(@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.223):
-    dependencies:
-      '@sveltejs/kit': 2.5.28(@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.223)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))
-      svelte: 5.0.0-next.223
+      '@sveltejs/kit': 2.5.28(@sveltejs/vite-plugin-svelte@4.0.0-next.7(svelte@5.0.0-next.257)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6)))(svelte@5.0.0-next.257)(vite@5.4.7(@types/node@20.16.5)(terser@5.31.6))
+      svelte: 5.0.0-next.257
 
   symbol-tree@3.2.4: {}
 
@@ -11357,10 +11332,10 @@ snapshots:
     dependencies:
       is-typedarray: 1.0.0
 
-  typescript-svelte-plugin@0.3.41(svelte@5.0.0-next.223)(typescript@5.6.2):
+  typescript-svelte-plugin@0.3.41(svelte@5.0.0-next.257)(typescript@5.6.2):
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
-      svelte2tsx: 0.7.18(svelte@5.0.0-next.223)(typescript@5.6.2)
+      svelte2tsx: 0.7.18(svelte@5.0.0-next.257)(typescript@5.6.2)
     transitivePeerDependencies:
       - svelte
       - typescript

--- a/src/lib/Image.svelte
+++ b/src/lib/Image.svelte
@@ -1,0 +1,53 @@
+<script lang='ts'>
+	type EnhancedImg = typeof import('*.png?enhanced').default;
+
+	type Props = {
+		src: string;
+		alt: string;
+	} & { [key: string]: unknown };
+
+	const { src, alt, ...rest }: Props = $props();
+
+	function importImage(src: string): EnhancedImg | undefined {
+		const pictures = import.meta.glob(`/src/**/*.{gif,heif,jpeg,jpg,png,tiff,webp}`, {
+			import: 'default',
+			query: {
+				enhanced: true,
+				w: '2400;2000;1600;1200;800;400',
+			},
+			eager: true,
+		});
+
+		for (const [path, picutureSrc] of Object.entries(pictures)) {
+			if (path.includes(src) || src.includes(path)) {
+				return picutureSrc as EnhancedImg;
+			}
+		}
+		return undefined;
+	}
+</script>
+
+{#snippet img(src: string)}
+	<img
+		{alt}
+		loading='lazy'
+		{src}
+		{...rest}
+	/>
+{/snippet}
+
+{#if src.startsWith('http')}
+	{@render img(src)}
+{:else}
+	{@const enhancedSrc = importImage(src)}
+	{#if enhancedSrc != null}
+		<enhanced:img
+			{alt}
+			loading='lazy'
+			src={enhancedSrc}
+			{...rest}
+		/>
+	{:else}
+		{@render img(src)}
+	{/if}
+{/if}

--- a/src/lib/Konami/Konami.svelte.ts
+++ b/src/lib/Konami/Konami.svelte.ts
@@ -44,8 +44,7 @@ export class Konami {
 			return;
 		}
 
-		on(window, 'keyup', (_event) => {
-			const { key } = _event as KeyboardEvent;
+		on(window, 'keyup', ({ key }) => {
 			const now = Date.now();
 
 			/** 有効なキーが入力されていない場合はコンボをリセット */

--- a/src/lib/Logo/AmazonMusic.svelte
+++ b/src/lib/Logo/AmazonMusic.svelte
@@ -1,12 +1,11 @@
 <script lang='ts'>
 	import { LINKS } from '../links';
 	import Base from './_Base.svelte';
-	// @ts-ignore
-	import icon from '$/assets/logos/icon-amazon-music.png?enhanced&w=300;600;800';
 
 	const { ...rest } = $props();
 
 	const { label: alt, url: link } = LINKS.AmazonMusic;
+	const icon = '/src/assets/logos/icon-amazon-music.png';
 </script>
 
 <Base {alt} {icon} {link} {...rest} />

--- a/src/lib/Logo/ApplePodcast.svelte
+++ b/src/lib/Logo/ApplePodcast.svelte
@@ -1,12 +1,11 @@
 <script lang='ts'>
 	import { LINKS } from '../links';
 	import Base from './_Base.svelte';
-	// @ts-ignore
-	import icon from '$/assets/logos/icon-apple-podcast.png?enhanced&w=300;600;800';
 
 	const { ...rest } = $props();
 
 	const { label: alt, url: link } = LINKS.ApplePodcast;
+	const icon = '/src/assets/logos/icon-apple-podcast.png';
 </script>
 
 <Base {alt} {icon} {link} {...rest} />

--- a/src/lib/Logo/AuDee.svelte
+++ b/src/lib/Logo/AuDee.svelte
@@ -1,5 +1,4 @@
 <script lang='ts'>
-	import icon from '$/assets/logos/logo-audee.svg';
 	import { LINKS } from '../links';
 	import Base from './_Base.svelte';
 
@@ -8,6 +7,7 @@
 	const { label: alt, url: link } = LINKS.AuDee;
 	const width = 123.836;
 	const height = 66.126;
+	const icon = '/src/assets/logos/logo-audee.svg';
 </script>
 
 <Base {alt} {height} {icon} {link} {width} {...rest} />

--- a/src/lib/Logo/AuDee.svelte
+++ b/src/lib/Logo/AuDee.svelte
@@ -1,4 +1,5 @@
 <script lang='ts'>
+	import icon from '$/assets/logos/logo-audee.svg?url';
 	import { LINKS } from '../links';
 	import Base from './_Base.svelte';
 
@@ -7,7 +8,6 @@
 	const { label: alt, url: link } = LINKS.AuDee;
 	const width = 123.836;
 	const height = 66.126;
-	const icon = '/src/assets/logos/logo-audee.svg';
 </script>
 
 <Base {alt} {height} {icon} {link} {width} {...rest} />

--- a/src/lib/Logo/GitHub.svelte
+++ b/src/lib/Logo/GitHub.svelte
@@ -1,11 +1,10 @@
 <script lang='ts'>
 	import Base from './_Base.svelte';
-	// @ts-ignore
-	import icon from '$/assets/logos/icon-github.png?enhanced&w=300;600;800';
 
 	const { ...rest } = $props();
 
 	const alt = `github`;
+	const icon = '/src/assets/logos/icon-github.png';
 </script>
 
 <Base {alt} {icon} {...rest} />

--- a/src/lib/Logo/Home.svelte
+++ b/src/lib/Logo/Home.svelte
@@ -1,11 +1,10 @@
 <script lang='ts'>
 	import Base from './_Base.svelte';
-	// @ts-ignore
-	import icon from '$/assets/logos/icon-home.png?enhanced&w=300;600;800';
 
 	const { ...rest } = $props();
 
 	const alt = `Home icon`;
+	const icon = '/src/assets/logos/icon-home.png';
 </script>
 
 <Base {alt} {icon} {...rest} />

--- a/src/lib/Logo/Spotify.svelte
+++ b/src/lib/Logo/Spotify.svelte
@@ -1,12 +1,11 @@
 <script lang='ts'>
 	import { LINKS } from '../links';
 	import Base from './_Base.svelte';
-	// @ts-ignore
-	import icon from '$/assets/logos/icon-spotify.png?enhanced&w=300;600;800';
 
 	const { ...rest } = $props();
 
 	const { label: alt, url: link } = LINKS.Spotify;
+	const icon = '/src/assets/logos/icon-spotify.png';
 </script>
 
 <Base {alt} {icon} {link} {...rest} />

--- a/src/lib/Logo/Suzuri.svelte
+++ b/src/lib/Logo/Suzuri.svelte
@@ -1,12 +1,11 @@
 <script lang='ts'>
 	import { LINKS } from '../links';
 	import Base from './_Base.svelte';
-	// @ts-ignore
-	import icon from '$/assets/logos/logo-surisurikun.png?enhanced&w=300;600;800';
 
 	const { ...rest } = $props();
 
 	const { label: alt, url: link } = LINKS.Suzuri;
+	const icon = '/src/assets/logos/logo-surisurikun.png';
 </script>
 
 <Base {alt} {icon} {link} {...rest} />

--- a/src/lib/Logo/VimJpRadio.svelte
+++ b/src/lib/Logo/VimJpRadio.svelte
@@ -4,10 +4,8 @@
 	import { LINKS } from '../links';
 	import Base from './_Base.svelte';
 
-	// @ts-ignore
-	import icon from '$/assets/vimjp-radio-cover-art/3000x3000-alpha-fs8.png?enhanced&w=200;400;600;800;1000;1200;1600;2000;2400;3000';
-
 	const { label: alt } = LINKS.VimJpRadio;
+	const icon = '/src/assets/vimjp-radio-cover-art/3000x3000-alpha-fs8.png';
 </script>
 
 <Base {alt} {icon} {...rest} />

--- a/src/lib/Logo/X.svelte
+++ b/src/lib/Logo/X.svelte
@@ -2,14 +2,13 @@
 	import type { ComponentProps } from 'svelte';
 	import { LINKS } from '../links';
 	import Base from './_Base.svelte';
-	// @ts-ignore
-	import icon from '$/assets/logos/logo-x.png?enhanced&w=300;600;800';
 
 	const { ...rest }: Omit<ComponentProps<Base>, 'icon'> = $props();
 
 	const { label: alt, url } = LINKS.X;
 
 	const link = rest.link ?? url;
+	const icon = '/src/assets/logos/logo-x.png';
 </script>
 
 <Base {alt} {icon} {link} {...rest} />

--- a/src/lib/Logo/YouTube.svelte
+++ b/src/lib/Logo/YouTube.svelte
@@ -1,12 +1,11 @@
 <script lang='ts'>
 	import { LINKS } from '../links';
 	import Base from './_Base.svelte';
-	// @ts-ignore
-	import icon from '$/assets/logos/icon-youtube.png?enhanced&w=300;600;800';
 
 	const { ...rest } = $props();
 
 	const { label: alt, url: link } = LINKS.Youtube;
+	const icon = '/src/assets/logos/icon-youtube.png';
 </script>
 
 <Base {alt} {icon} {link} {...rest} />

--- a/src/lib/Logo/_Base.svelte
+++ b/src/lib/Logo/_Base.svelte
@@ -1,36 +1,22 @@
 <script lang='ts'>
-	import type dummyEnhanced from '*?enhanced';
 	import type { HTMLImgAttributes } from 'svelte/elements';
+	import Image from '../Image.svelte';
 	import { ensureURL } from '../utils/url';
 
-	type Picture = typeof dummyEnhanced;
-
-	const { link, icon, alt, class: className, ...rest }: { link?: string; icon: string | Picture } & Omit<HTMLImgAttributes, 'src'> = $props();
+	const { link, icon, alt, class: className, ...rest }: { link?: string; icon: string } & Omit<HTMLImgAttributes, 'src'> = $props();
 
 	const _defaultClassName = `h-full object-scale-down w-auto`;
 	const _className = className ?? _defaultClassName;
 	const loading: typeof rest.loading = 'loading' in rest ? rest.loading : `lazy`;
-
 </script>
 {#snippet image()}
-{#if typeof icon === 'string' && icon.endsWith('.svg')}
-<!-- svg image -->
-<img
-	class={_className}
-	{alt}
-	{loading}
-	src={icon}
-	{...rest}
-/>
-{:else}
-	<enhanced:img
+	<Image
 		class={_className}
-		{alt}
+		alt={alt as string}
 		{loading}
 		src={icon}
 		{...rest}
 	/>
-  {/if}
 {/snippet}
 
 {#if link != null}

--- a/src/lib/utils/runes.svelte.ts
+++ b/src/lib/utils/runes.svelte.ts
@@ -28,8 +28,7 @@ export class PrefersReducedMotion {
 
 		this.#mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
 		this.#isReduced = this.#mediaQuery.matches;
-		on(this.#mediaQuery, 'change', (_event) => {
-			const event = _event as MediaQueryListEvent;
+		on(this.#mediaQuery, 'change', (event) => {
 			this.#isReduced = event.matches;
 		});
 	}

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -2,6 +2,7 @@
 	import { Konami } from '$/lib/Konami';
 	import { dev } from '$app/environment';
 	import { page } from '$app/stores';
+	import Image from '$lib/Image.svelte';
 
 	const konami = new Konami(2000);
 
@@ -19,11 +20,11 @@
 		uno-place='content-center items-center'
 	>
 		<!-- EASTER_EGG🐰🥚: Konamiコマンドが認識されると、`konami.activated`が`true`になり、`animate-spin`が適用されます。 -->
-		<enhanced:img
-			class:animate-spin={konami.activated}
+		<Image
+			class={konami.activated && 'animate-spin'}
 			alt='error logo'
 			loading='lazy'
-			src='$/assets/alisue/beer.png'
+			src='/src/assets/alisue/beer.png'
 		/>
 		<span uno-text>
 			{$page.error.message}

--- a/src/routes/Personalities.svelte
+++ b/src/routes/Personalities.svelte
@@ -1,7 +1,4 @@
 <script lang='ts'>
-	import lambdalisueImg from '$/assets/avatar/lambdalisue.png?enhanced';
-	import tomoyaImg from '$/assets/avatar/tomoya.jpg?enhanced';
-
 	import { Heading } from '$/lib/Heading';
 	import Personality from './Personality.svelte';
 </script>
@@ -13,7 +10,7 @@
 			name='tomoya'
 			ghLink='https://github.com/tomoya'
 			homeLink='https://blog.tomoya.dev/'
-			imgSrc={tomoyaImg}
+			imgSrc='/src/assets/avatar/tomoya.jpg'
 			xLink='https://x.com/tomoyaton'
 		>
 			<!-- 文字列を渡すだけだとBudouXが処理できない（コードにあるtagをpreprocessしなければならない都合）ので、pタグで囲む -->
@@ -28,7 +25,7 @@
 		<Personality
 			name='ありすえ'
 			ghLink='https://github.com/lambdalisue'
-			imgSrc={lambdalisueImg}
+			imgSrc='/src/assets/avatar/lambdalisue.png'
 			xLink='https://twitter.com/lambdalisue'
 		>
 			<!-- 文字列を渡すだけだとBudouXが処理できない（コードにあるtagをpreprocessしなければならない都合）ので、pタグで囲む -->

--- a/src/routes/Personality.svelte
+++ b/src/routes/Personality.svelte
@@ -1,9 +1,7 @@
 <script lang='ts'>
-	import type dummyEnhanced from '*?enhanced';
 	import type { Snippet } from 'svelte';
+	import Image from '$lib/Image.svelte';
 	import * as Logo from '$lib/Logo';
-
-	type Picture = typeof dummyEnhanced;
 
 	const {
 		name,
@@ -14,7 +12,7 @@
 		homeLink,
 	}: {
 		name: string;
-		imgSrc: Picture;
+		imgSrc: string;
 		children: Snippet<[]>;
 		xLink?: string;
 		ghLink?: string;
@@ -59,10 +57,9 @@
 
 	<div>
 		<!-- プロフ画像 -->
-		<enhanced:img
+		<Image
 			class='float-right ml-10px h-auto w-100px'
 			alt={name}
-			loading='lazy'
 			src={imgSrc}
 		/>
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -4,7 +4,6 @@ import adapter from '@sveltejs/adapter-static';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 import { isDevelopment } from 'std-env';
 import { budouxPreprocess } from 'svelte-preprocess-budoux';
-import htmlMinifierAdaptor from 'sveltekit-html-minifier';
 
 /** @param {...string} args */
 function relativePath(...args) {
@@ -33,11 +32,9 @@ const config = {
 		// adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
 		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
 		// See https://kit.svelte.dev/docs/adapters for more information about adapters.
-		adapter: htmlMinifierAdaptor(
-			adapter({
-				fallback: '404.html',
-			}),
-		),
+		adapter: adapter({
+			fallback: '404.html',
+		}),
 
 		typescript: {
 			config(config) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,9 @@ function relativePath(...args: string[]): string {
 const background = theme.colors.LP.backgroud;
 
 export default defineConfig({
+	build: {
+		minify: false,
+	},
 	plugins: [
 		/* favicon と metadata の設定 */
 		faviconsPlugin({


### PR DESCRIPTION
ryoppippi.comの実装において、enhanced:imgをラップしたコンポーネントを用いると取り回しが良かったので採用する