### PR TITLE
Update credit

### DIFF
--- a/src/routes/Footer.svelte
+++ b/src/routes/Footer.svelte
@@ -29,7 +29,7 @@
 			Theme music: Jun Tanaka (GENTOUKI)<br />
 			Cover art design: Kazuaki Komai (こまゐ図考室)<br />
 			Production: Sha-la-la Company<br />
-			vim-jp radio team: atusy, conao3, emtee, gamoutatsumi, hakkadaikon, kawarimidoll, kyoh86, mikan, na0x2c6, peacock, ryoppippi, ryuichiroh, shishi, tani, and wagomu
+			vim-jp radio team: conao3, kawarimidoll, kleha, ryoppippi, and wagomu
 		</p>
 		<p uno-color-LP-gray uno-text-sm>(c) Forcode Co., Ltd.</p>
 	</div>


### PR DESCRIPTION
vim-jp radioの制作メンバー入れ替えに対応させる形でfooterのvim-jp radio teamの欄を変更しました。
![image](https://github.com/user-attachments/assets/df27e58e-4b3f-4557-9ca2-1dc868288106)
