### PR TITLE
feat: add fetchpriority to logo image

### DIFF
--- a/src/routes/Header.svelte
+++ b/src/routes/Header.svelte
@@ -9,6 +9,6 @@
 		uno-m-0
 		uno-place='content-center items-center'
 	>
-		<VimJpRadio class='h-auto max-w-100% w-50svh' loading={null} />
+		<VimJpRadio class='h-auto max-w-100% w-50svh' fetchpriority='high' loading={null} />
 	</h1>
 </header>


### PR DESCRIPTION
This pull request includes a small change to the `src/routes/Header.svelte` file. The change adds a `fetchpriority='high'` attribute to the `VimJpRadio` component to optimize loading priority.