### PR TITLE
feat: add episode timeline with guest tags

### DIFF
--- a/src/lib/Logo/ApplePodcast.svelte
+++ b/src/lib/Logo/ApplePodcast.svelte
@@ -4,9 +4,10 @@
 	import { LINKS } from '../links';
 	import Base from './_Base.svelte';
 
-	const { ...rest } = $props();
+	const { link: linkOverride, ...rest }: { link?: string } & Record<string, unknown> = $props();
 
-	const { label: alt, url: link } = LINKS.ApplePodcast;
+	const { label: alt, url } = LINKS.ApplePodcast;
+	const link = linkOverride ?? url;
 </script>
 
 <Base {alt} {icon} {link} {...rest} />

--- a/src/lib/Logo/YouTube.svelte
+++ b/src/lib/Logo/YouTube.svelte
@@ -3,9 +3,10 @@
 	import { LINKS } from '../links';
 	import Base from './_Base.svelte';
 
-	const { ...rest } = $props();
+	const { link: linkOverride, ...rest }: { link?: string } & Record<string, unknown> = $props();
 
-	const { label: alt, url: link } = LINKS.Youtube;
+	const { label: alt, url } = LINKS.Youtube;
+	const link = linkOverride ?? url;
 </script>
 
 <Base {alt} {icon} {link} {...rest} />

--- a/src/lib/guests.ts
+++ b/src/lib/guests.ts
@@ -1,0 +1,175 @@
+export const RSS_FEED_URL = 'https://feeds.megaphone.fm/TFM3978755021';
+
+export interface Episode {
+	number: number;
+	title: string;
+	date: string;
+	guests: string[];
+	links?: {
+		applePodcast?: string;
+		youtube?: string;
+	};
+}
+
+interface FeedEpisode extends Omit<Episode, 'guests'> {
+	description: string;
+}
+
+const EXCLUDED_NAMES = new Set(['tomoya', 'ありすえ']);
+const KNOWN_GUEST_NAMES = [
+	'naota',
+	'ryoppippi',
+	'maguro',
+	'市川達大',
+	'Kyohei',
+	'稲尾',
+	'mattn',
+	'あおい',
+	'mozumasu',
+	'寺田純路',
+	'藤巻俊一',
+	'ゴリラ',
+	'たけてぃ',
+	'aizawa',
+	'Sosuke Suzuki',
+	'Piro',
+	'ちっくん',
+	'giginet',
+	'西山信行',
+	'丸田康司',
+	'edvakf',
+	'kyuns',
+	'田中潤',
+	't-wada',
+	'tadsan',
+	'Dr.tani',
+	'yuys13',
+	'kat0h',
+	'ujihisa',
+	'mopp',
+	'vaaaaanquish',
+	'mizchi',
+	'k-takata',
+	'thinca',
+	'uzulla',
+	'yusukebe',
+	'Shougo',
+	'KoRoN',
+] as const;
+
+export function buildGuestEpisodesFromFeedXml(xml: string): Episode[] {
+	return parseFeedEpisodes(xml)
+		.map(episode => ({
+			number: episode.number,
+			title: episode.title,
+			date: episode.date,
+			guests: extractGuestNames(episode),
+		}))
+		.filter(episode => episode.guests.length > 0)
+		.sort((a, b) => b.number - a.number);
+}
+
+function parseFeedEpisodes(xml: string): FeedEpisode[] {
+	return [...xml.matchAll(/<item>[\s\S]*?<\/item>/g)]
+		.map(match => match[0])
+		.map((item) => {
+			const title = normalizeText(getTagText(item, 'title'));
+			const episodeNumber = title.match(/#(\d+)/)?.[1];
+			const pubDate = getTagText(item, 'pubDate');
+
+			return {
+				number: episodeNumber == null ? 0 : Number(episodeNumber),
+				title: title.match(/【(.+?)】/)?.[1] ?? title.replace(/エンジニアの楽園 vim-jp ラジオ #\d+$/, '').trim(),
+				date: new Date(pubDate).toISOString().slice(0, 10),
+				description: normalizeText(getTagText(item, 'description')),
+			};
+		})
+		.filter(episode => episode.number > 0);
+}
+
+function getTagText(xml: string, tag: string): string {
+	return decodeXml(xml.match(new RegExp(`<${tag}(?: [^>]*)?>([\\s\\S]*?)<\\/${tag}>`))?.[1] ?? '');
+}
+
+function extractGuestNames(episode: FeedEpisode): string[] {
+	const intro = `${episode.title}。${getLeadText(episode.description)}`;
+
+	if (intro.includes('ゲストなし')) {
+		return [];
+	}
+
+	const names = [...intro.matchAll(/さん/g)]
+		.map(match => cleanGuestName(intro.slice(0, match.index)))
+		.map(canonicalizeGuestName)
+		.filter(name => name.length > 0 && !EXCLUDED_NAMES.has(name));
+
+	return [...new Set(names)];
+}
+
+function getLeadText(text: string): string {
+	return getIntroText(text).split(/今回の(?:トーク)?テーマ|そして、エンディング/)[0];
+}
+
+function getIntroText(text: string): string {
+	return text
+		.split(/〜〜〜|～～～|【vim-jp ラジオ インフォメーション】/)[0]
+		.replace(/エンジニアコミュニティ「vim-jp」のラジオ版としてスタートした「エンジニアの楽園 vim-jp ラジオ」。/g, '')
+		.replace(/WEBコミュニティ「vim-jp」のラジオ版としてスタートした「エンジニアの楽園 vim-jp ラジオ」。/g, '');
+}
+
+function cleanGuestName(textBeforeSan: string): string {
+	const sentence = textBeforeSan.slice(Math.max(
+		textBeforeSan.lastIndexOf('。'),
+		textBeforeSan.lastIndexOf('！'),
+		textBeforeSan.lastIndexOf('？'),
+		textBeforeSan.lastIndexOf('\n'),
+	) + 1);
+
+	return sentence
+		.replace(/^.*さん[と・、]/, '')
+		.split('、')
+		.at(-1)!
+		.replace(/^.*(?:の|こと)/, '')
+		.replace(/^(?:そして|同じく|初の女性ゲスト|番組初のゲスト|ゲスト|「|『)+/, '')
+		.replace(/[「」『』（）()]/g, '')
+		.trim();
+}
+
+function canonicalizeGuestName(name: string): string {
+	const normalizedName = name.replace(/^◯/, '').trim();
+	const candidates = KNOWN_GUEST_NAMES
+		.filter(guestName => normalizedName.includes(guestName) || (normalizedName.length >= 2 && guestName.startsWith(normalizedName)))
+		.sort((a, b) => b.length - a.length);
+
+	if (candidates[0] != null) {
+		return candidates[0];
+	}
+
+	return isLikelyGuestName(normalizedName) ? normalizedName : '';
+}
+
+function isLikelyGuestName(name: string): boolean {
+	const nameParts = name.split(' ');
+
+	return name.length <= 24
+		&& nameParts.length <= 2
+		&& nameParts.every(part => /^[\p{Letter}\p{Number}_.-]+$/u.test(part))
+		&& !/今回|テーマ|について|から|まで|して|され|だった|いる|たく|もちろん/.test(name);
+}
+
+function normalizeText(text: string): string {
+	return text
+		.replace(/<!\[CDATA\[|\]\]>/g, '')
+		.replace(/<[^>]+>/g, ' ')
+		.replace(/\s+/g, ' ')
+		.trim();
+}
+
+function decodeXml(text: string): string {
+	return text
+		.replaceAll('&amp;', '&')
+		.replaceAll('&lt;', '<')
+		.replaceAll('&gt;', '>')
+		.replaceAll('&quot;', '"')
+		.replaceAll('&apos;', '\'');
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang='ts'>
 	import { Background } from '$lib/Background';
 	import EasterEgg from './EasterEgg.svelte';
+	import Footer from './Footer.svelte';
 
 	import Meta from './Meta.svelte';
 	import 'uno.css';
@@ -25,6 +26,7 @@
 	uno-z-1
 >
 	{@render children()}
+	<Footer />
 </div>
 
 <style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script>
 	import Description from './Description.svelte';
+	import GuestsLink from './GuestsLink.svelte';
 	import Header from './Header.svelte';
 	import ListenersTweets from './ListenersTweets.svelte';
 	import Personalities from './Personalities.svelte';
@@ -12,6 +13,7 @@
 <main uno-flex-col uno-space-y-16>
 	<Description />
 	<Platforms />
+	<GuestsLink />
 	<Personalities />
 	<RadioLetter />
 	<ListenersTweets />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,5 @@
 <script>
 	import Description from './Description.svelte';
-	import Footer from './Footer.svelte';
 	import Header from './Header.svelte';
 	import ListenersTweets from './ListenersTweets.svelte';
 	import Personalities from './Personalities.svelte';
@@ -17,5 +16,3 @@
 	<RadioLetter />
 	<ListenersTweets />
 </main>
-
-<Footer />

--- a/src/routes/GuestsLink.svelte
+++ b/src/routes/GuestsLink.svelte
@@ -1,0 +1,11 @@
+<script lang='ts'>
+	import { Heading } from '$lib/Heading';
+</script>
+
+<section data-budoux uno-flex='~ col gap-5'>
+	<Heading title='ゲスト出演回' />
+	<p uno-text>
+		番組初ゲストのKoRoNさんから最新回まで、ゲスト出演回をタイムラインでまとめています。
+	</p>
+	<a href='/episodes' uno-button>タイムラインを見る</a>
+</section>

--- a/src/routes/episodes/+page.server.ts
+++ b/src/routes/episodes/+page.server.ts
@@ -1,0 +1,94 @@
+import type { PageServerLoad } from './$types';
+import { buildGuestEpisodesFromFeedXml, RSS_FEED_URL } from '$lib/guests';
+
+interface ApplePodcastEpisode {
+	trackName?: string;
+	trackViewUrl?: string;
+}
+
+interface ApplePodcastLookupResponse {
+	results?: ApplePodcastEpisode[];
+}
+
+const YOUTUBE_PLAYLIST_FEED_URL = 'https://www.youtube.com/feeds/videos.xml?playlist_id=PLcptmT4PuRVNm5qjf5DhzPYZenncjLWQ8';
+
+export const load: PageServerLoad = async ({ fetch }) => {
+	const response = await fetch(RSS_FEED_URL);
+
+	if (!response.ok) {
+		throw new Error(`Failed to fetch podcast feed: ${response.status}`);
+	}
+
+	const episodes = buildGuestEpisodesFromFeedXml(await response.text());
+	const [applePodcastLinks, youtubeLinks] = await Promise.all([
+		fetchApplePodcastLinks(fetch),
+		fetchYoutubeLinks(fetch),
+	]);
+	const guests = new Set(episodes.flatMap(episode => episode.guests));
+
+	return {
+		episodeCount: episodes.length,
+		guestCount: guests.size,
+		episodes: episodes.map(episode => ({
+			...episode,
+			links: {
+				applePodcast: applePodcastLinks.get(episode.number),
+				youtube: youtubeLinks.get(episode.number),
+			},
+		})),
+	};
+};
+
+async function fetchApplePodcastLinks(fetch: typeof globalThis.fetch): Promise<Map<number, string>> {
+	const response = await fetch('https://itunes.apple.com/lookup?id=1755104750&entity=podcastEpisode&limit=200&country=JP');
+
+	if (!response.ok) {
+		return new Map();
+	}
+
+	const data = await response.json() as ApplePodcastLookupResponse;
+	const links = new Map<number, string>();
+
+	for (const episode of data.results ?? []) {
+		const episodeNumber = episode.trackName?.match(/#(\d+)/)?.[1];
+
+		if (episodeNumber != null && episode.trackViewUrl != null) {
+			links.set(Number(episodeNumber), episode.trackViewUrl);
+		}
+	}
+
+	return links;
+}
+
+async function fetchYoutubeLinks(fetch: typeof globalThis.fetch): Promise<Map<number, string>> {
+	const response = await fetch(YOUTUBE_PLAYLIST_FEED_URL);
+
+	if (!response.ok) {
+		return new Map();
+	}
+
+	const feed = await response.text();
+	const links = new Map<number, string>();
+
+	for (const match of feed.matchAll(/<entry>[\s\S]*?<\/entry>/g)) {
+		const entry = match[0];
+		const title = decodeXml(entry.match(/<title>([\s\S]*?)<\/title>/)?.[1] ?? '');
+		const episodeNumber = title.match(/#(\d+)/)?.[1];
+		const url = decodeXml(entry.match(/<link rel="alternate" href="([^"]+)"/)?.[1] ?? '');
+
+		if (episodeNumber != null && url !== '') {
+			links.set(Number(episodeNumber), url);
+		}
+	}
+
+	return links;
+}
+
+function decodeXml(text: string): string {
+	return text
+		.replaceAll('&amp;', '&')
+		.replaceAll('&lt;', '<')
+		.replaceAll('&gt;', '>')
+		.replaceAll('&quot;', '"')
+		.replaceAll('&#39;', '\'');
+}

--- a/src/routes/episodes/+page.svelte
+++ b/src/routes/episodes/+page.svelte
@@ -1,0 +1,107 @@
+<script lang='ts'>
+	import type { PageData } from './$types';
+	import { Heading } from '$lib/Heading';
+	import { VIM_JP_RADIO_INFO } from '$lib/links';
+	import * as Logo from '$lib/Logo';
+
+	const { data }: { data: PageData } = $props();
+
+	const description = `エンジニアの楽園 vim-jp ラジオのゲスト出演回タイムラインです。`;
+	const title = `ゲスト出演回タイムライン | ${VIM_JP_RADIO_INFO.title}`;
+	const dateFormatter = new Intl.DateTimeFormat('ja-JP', {
+		dateStyle: 'medium',
+		timeZone: 'Asia/Tokyo',
+	});
+</script>
+
+<svelte:head>
+	<title>{title}</title>
+	<meta name='description' content={description} />
+</svelte:head>
+
+<main uno-flex-col uno-py-16 uno-space-y-12>
+	<section data-budoux uno-flex='~ col gap-6'>
+		<a href='/' uno-color-LP-blue uno-text-sm uno-w-fit>← トップへ戻る</a>
+
+		<div uno-flex='~ col gap-4'>
+			<Heading title='ゲスト出演回' />
+			<p uno-text>
+				「エンジニアの楽園 vim-jp ラジオ」のゲスト出演回を時系列でまとめています。
+				各エピソードのゲストはタグで確認できます。
+			</p>
+		</div>
+
+		<div
+			uno-grid='~ cols-2 gap-3'
+			uno-tiny='grid-cols-3'
+		>
+			<div uno-border='solid 1 LP-darkGray/70' uno-p-4 uno-rounded-2>
+				<p uno-color-LP-gray uno-text-xs>Guests</p>
+				<p uno-color-LP-yellow uno-font-bold uno-text-2xl>{data.guestCount}</p>
+			</div>
+			<div uno-border='solid 1 LP-darkGray/70' uno-p-4 uno-rounded-2>
+				<p uno-color-LP-gray uno-text-xs>Episodes</p>
+				<p uno-color-LP-yellow uno-font-bold uno-text-2xl>{data.episodeCount}</p>
+			</div>
+			<div uno-border='solid 1 LP-darkGray/70' uno-p-4 uno-rounded-2>
+				<p uno-color-LP-gray uno-text-xs>Since</p>
+				<p uno-color-LP-yellow uno-font-bold uno-text-2xl>#5</p>
+			</div>
+		</div>
+	</section>
+
+	<section
+		aria-label='ゲスト出演回タイムライン'
+		uno-flex='~ col gap-0'
+	>
+		{#each data.episodes as episode (episode.number)}
+			<article
+				uno-border-l='solid 1 LP-darkGray'
+				uno-flex='~ gap-4'
+				uno-ml-4
+				uno-pb-8
+				uno-pl-5
+				uno-relative
+			>
+				<div uno-flex='~ col gap-3' uno-w-full>
+					<div uno-flex='~ wrap items-center gap-2'>
+						<span uno-color-LP-yellow uno-font-bold uno-text-sm>{`#${episode.number}`}</span>
+						<time datetime={episode.date} uno-color-LP-gray uno-text-xs>
+							{dateFormatter.format(new Date(`${episode.date}T00:00:00+09:00`))}
+						</time>
+					</div>
+
+					<h2 uno-color-LP-blue uno-font-bold uno-m-0 uno-text-xl>
+						{episode.title}
+					</h2>
+
+					<ul uno-flex='~ wrap gap-2' uno-list-none uno-m-0 uno-p-0>
+						{#each episode.guests as guest (guest)}
+							<li
+								uno-border='solid 1 LP-yellow/70'
+								uno-color-LP-yellow
+								uno-px-3
+								uno-py-1
+								uno-rounded-full
+								uno-text-xs
+							>
+								{guest}
+							</li>
+						{/each}
+					</ul>
+
+					{#if episode.links?.applePodcast != null || episode.links?.youtube != null}
+						<div aria-label='エピソードリンク' uno-flex uno-gap-3 uno-h-7>
+							{#if episode.links.applePodcast != null}
+								<Logo.ApplePodcast link={episode.links.applePodcast} />
+							{/if}
+							{#if episode.links.youtube != null}
+								<Logo.YouTube link={episode.links.youtube} />
+							{/if}
+						</div>
+					{/if}
+				</div>
+			</article>
+		{/each}
+	</section>
+</main>

--- a/src/routes/episodes/+page.svelte
+++ b/src/routes/episodes/+page.svelte
@@ -1,10 +1,10 @@
 <script lang='ts'>
-	import type { PageData } from './$types';
 	import { Heading } from '$lib/Heading';
 	import { VIM_JP_RADIO_INFO } from '$lib/links';
 	import * as Logo from '$lib/Logo';
+	import { getGuestEpisodes } from './episodes.remote';
 
-	const { data }: { data: PageData } = $props();
+	const data = await getGuestEpisodes();
 
 	const description = `エンジニアの楽園 vim-jp ラジオのゲスト出演回タイムラインです。`;
 	const title = `ゲスト出演回タイムライン | ${VIM_JP_RADIO_INFO.title}`;

--- a/src/routes/episodes/episodes.remote.ts
+++ b/src/routes/episodes/episodes.remote.ts
@@ -1,4 +1,4 @@
-import type { PageServerLoad } from './$types';
+import { prerender } from '$app/server';
 import { buildGuestEpisodesFromFeedXml, RSS_FEED_URL } from '$lib/guests';
 
 interface ApplePodcastEpisode {
@@ -10,9 +10,10 @@ interface ApplePodcastLookupResponse {
 	results?: ApplePodcastEpisode[];
 }
 
-const YOUTUBE_PLAYLIST_FEED_URL = 'https://www.youtube.com/feeds/videos.xml?playlist_id=PLcptmT4PuRVNm5qjf5DhzPYZenncjLWQ8';
+const YOUTUBE_PLAYLIST_ID = 'PLcptmT4PuRVNm5qjf5DhzPYZenncjLWQ8';
+const YOUTUBE_PLAYLIST_URL = `https://www.youtube.com/playlist?list=${YOUTUBE_PLAYLIST_ID}`;
 
-export const load: PageServerLoad = async ({ fetch }) => {
+export const getGuestEpisodes = prerender(async () => {
 	const response = await fetch(RSS_FEED_URL);
 
 	if (!response.ok) {
@@ -21,8 +22,8 @@ export const load: PageServerLoad = async ({ fetch }) => {
 
 	const episodes = buildGuestEpisodesFromFeedXml(await response.text());
 	const [applePodcastLinks, youtubeLinks] = await Promise.all([
-		fetchApplePodcastLinks(fetch),
-		fetchYoutubeLinks(fetch),
+		fetchApplePodcastLinks(),
+		fetchYoutubeLinks(),
 	]);
 	const guests = new Set(episodes.flatMap(episode => episode.guests));
 
@@ -37,9 +38,9 @@ export const load: PageServerLoad = async ({ fetch }) => {
 			},
 		})),
 	};
-};
+});
 
-async function fetchApplePodcastLinks(fetch: typeof globalThis.fetch): Promise<Map<number, string>> {
+async function fetchApplePodcastLinks(): Promise<Map<number, string>> {
 	const response = await fetch('https://itunes.apple.com/lookup?id=1755104750&entity=podcastEpisode&limit=200&country=JP');
 
 	if (!response.ok) {
@@ -60,35 +61,37 @@ async function fetchApplePodcastLinks(fetch: typeof globalThis.fetch): Promise<M
 	return links;
 }
 
-async function fetchYoutubeLinks(fetch: typeof globalThis.fetch): Promise<Map<number, string>> {
-	const response = await fetch(YOUTUBE_PLAYLIST_FEED_URL);
+async function fetchYoutubeLinks(): Promise<Map<number, string>> {
+	const response = await fetch(YOUTUBE_PLAYLIST_URL);
 
 	if (!response.ok) {
 		return new Map();
 	}
 
-	const feed = await response.text();
+	return parseYoutubePlaylistLinks(await response.text());
+}
+
+function parseYoutubePlaylistLinks(html: string): Map<number, string> {
 	const links = new Map<number, string>();
 
-	for (const match of feed.matchAll(/<entry>[\s\S]*?<\/entry>/g)) {
-		const entry = match[0];
-		const title = decodeXml(entry.match(/<title>([\s\S]*?)<\/title>/)?.[1] ?? '');
+	for (const match of html.matchAll(/"playlistVideoRenderer":\{"videoId":"([^"]+)"[\s\S]*?"title":\{"runs":\[\{"text":"((?:\\.|[^"\\])*)"\}\][\s\S]*?"index":\{"simpleText":"\d+"\}/g)) {
+		const [, videoId, encodedTitle] = match;
+		const title = decodeJsonString(encodedTitle);
 		const episodeNumber = title.match(/#(\d+)/)?.[1];
-		const url = decodeXml(entry.match(/<link rel="alternate" href="([^"]+)"/)?.[1] ?? '');
 
-		if (episodeNumber != null && url !== '') {
-			links.set(Number(episodeNumber), url);
+		if (episodeNumber != null) {
+			links.set(Number(episodeNumber), `https://www.youtube.com/watch?v=${videoId}&list=${YOUTUBE_PLAYLIST_ID}`);
 		}
 	}
 
 	return links;
 }
 
-function decodeXml(text: string): string {
-	return text
-		.replaceAll('&amp;', '&')
-		.replaceAll('&lt;', '<')
-		.replaceAll('&gt;', '>')
-		.replaceAll('&quot;', '"')
-		.replaceAll('&#39;', '\'');
+function decodeJsonString(text: string): string {
+	try {
+		return JSON.parse(`"${text}"`) as string;
+	}
+	catch {
+		return text;
+	}
 }


### PR DESCRIPTION
## Summary

- Add an /episodes timeline page that shows historical guest episodes with guest tags.
- Fetch episode data at static build time through a prerender remote function.
- Add per-episode platform links using Apple Podcasts lookup data and YouTube playlist page data so older videos can be linked where available.
- Move shared footer rendering into the root layout and reuse podcast logo components for episode-specific links.

## Testing

- pnpm check
- pnpm lint
- pnpm build
